### PR TITLE
Git objects with a SHA1 commencing '00' fail to be found in the pack files

### DIFF
--- a/lib/git/pack_storage.js
+++ b/lib/git/pack_storage.js
@@ -246,7 +246,7 @@ var unpack_compressed = function(pack, offset, destsize) {
 var find_object_in_index = function(pack, idx, sha1) {
   // Parse the first value of the sha as an index
   var slot = sha1.charCodeAt(0);
-  if(!slot) return null;
+  if(slot == NaN) return null;
   
   // Unpack the variables
   var first = pack.offsets[slot];


### PR DESCRIPTION
Currently if an object is unluck enough to have a SHA commencing 00 then the Pack_Storage 'find_object_in_index' code will not locate it.

I've supplied this as a dedicated separate pull request as I can't find a sensible way to test it, any ideas? (I'm currently testing on git's own 'git repository'.. the repository.log falls over early on as one of the shas starts 00...
