### PR TITLE
Fix `repo.tags` for a repo with no refs.

### DIFF
--- a/lib/git/tag.js
+++ b/lib/git/tag.js
@@ -20,6 +20,7 @@ Tag.find_all = function(repo, options, callback) {
   // Let's fetch the references
   repo.git.refs({}, prefix('tag'), function(err, refs) {    
     if(err) return callback(err, refs);
+    if(!refs) return callback(null, []);
     // Map the references
     var mapped_refs = refs.split(/\n/).map(function(ref) {
       // Fetch the name and id for the reference


### PR DESCRIPTION
For example, in my repo the git dir 'packed-refs' file looks like this:

```
# pack-refs with: peeled
dd1133c99ec2a0372e630249f36996f772df0953 refs/heads/master
```

In that case `Git.refs` returns the empty string.
