### PR TITLE
Add missing branch for log fetching

### DIFF
--- a/lib/git/git.js
+++ b/lib/git/git.js
@@ -613,7 +613,7 @@ Git.prototype.fs_write = function(file, content, callback) {
 
 // Log function, returns the number of logs
 Git.prototype.log = function(commit, path, options, callback) {
-  args = ['--raw', '--no-abbrev', '--numstat'];
+  args = [commit, '--raw', '--no-abbrev', '--numstat'];
   if (path) {
     args.push('--');
     args.push(path);


### PR DESCRIPTION
Given branch was ignored while fetching the logs, so you always got the master branch...
