### PR TITLE
Fix reference error

### DIFF
--- a/lib/git/repository.js
+++ b/lib/git/repository.js
@@ -693,6 +693,7 @@ Repository.prototype.get_subtree = function(commit_sha, path, callback) {
 Repository.init = function(dir, bare, callback) {
   try {    
     var args = Array.prototype.slice.call(arguments, 0);
+    var self = this;
     callback = args.pop();
     dir = args.length ? args.shift() : true;
     bare = args.length ? args.shift() : true;


### PR DESCRIPTION
Calling git init returns with an error, that self is not defined.

Example code:

```javascript
var git = require('git');
var path = require('path');
var fs = require('fs');
var repo = path.join(__dirname, String(Math.random() * 10000));

fs.mkdir(repo, function () {
    var g = new git.Git(repo);
    g.init({}, function (err, result) {
	console.log(err, result);
    });
});
```