### PR TITLE
GitCommit.raw_log only drop last msg line if blank

### DIFF
--- a/lib/git/internal/git_commit.js
+++ b/lib/git/internal/git_commit.js
@@ -65,9 +65,15 @@ GitCommit.from_raw = function(raw_object, repository) {
 GitCommit.prototype.raw_log = function(sha1) {
   var output = "commit " + sha1 + "\n";
   output = output + this.headers + "\n\n";
-  var lines = this.message.split("\n");    
-  // Remove the last line which will be empty
-  for(var i = 0; i < (lines.length > 1 ? lines.length - 1 : lines.length); i++) {
+  var lines = this.message.split("\n");
+  var length = lines.length;
+
+  // drop last line if it's blank
+  if (length > 0 && lines[length - 1].length === 0) {
+    length -= 1;
+  }
+
+  for(var i = 0; i < length; i++) {
     output = output + '    ' + lines[i] + '\n';
   }
   // Return the output

--- a/lib/git/internal/git_commit.js
+++ b/lib/git/internal/git_commit.js
@@ -70,11 +70,11 @@ GitCommit.prototype.raw_log = function(sha1) {
 
   // drop last line if it's blank
   if (length > 0 && lines[length - 1].length === 0) {
-    length -= 1;
+    length--;
   }
 
   for(var i = 0; i < length; i++) {
-    output = output + '    ' + lines[i] + '\n';
+    output += '    ' + lines[i] + '\n';
   }
   // Return the output
   return output + '\n';

--- a/test/test_git_basic.js
+++ b/test/test_git_basic.js
@@ -2,7 +2,7 @@ var testCase = require('nodeunit').testCase,
   Repo = require('../lib/git').Repo,
   Git = require('../lib/git').Git,
   fs = require('fs'),
-  Commit = require('../lib/git').Commit,
+  Commit = require('../lib/git/internal/git_commit').GitCommit,
   Blob = require('../lib/git').Blob,
   GitFileOperations = require('../lib/git').GitFileOperations;
 
@@ -22,6 +22,39 @@ module.exports = testCase({
   
   tearDown: function(callback) {
     callback();
+  },
+
+  "GitCommit.raw_log eliminates final empty line":function(assert) {
+    var message = 'first line\nsecond line\n';
+    var headers = 'headers';
+    var sha = 'SHA';
+
+    var expected = 'commit SHA\n' +
+      'headers\n\n' +
+      '    first line\n' +
+      '    second line\n\n';
+
+    var commit = new Commit(null, null, null, null, message, headers);
+
+    assert.equal(expected, commit.raw_log(sha));
+    assert.done();
+  },
+
+  "GitCommit.raw_log does not drop final line if non-empty":function(assert) {
+    var message = 'first line\nsecond line\nthird line';
+    var headers = 'headers';
+    var sha = 'SHA';
+
+    var expected = 'commit SHA\n' +
+      'headers\n\n' +
+      '    first line\n' +
+      '    second line\n' +
+      '    third line\n\n';
+
+    var commit = new Commit(null, null, null, null, message, headers);
+
+    assert.equal(expected, commit.raw_log(sha));
+    assert.done();
   },
 
   "Should correctly init gitdir":function(assert) {


### PR DESCRIPTION
Fixes the message-dropping behavior I saw, potentially the same thing as #38.